### PR TITLE
declare missing $circuit property in Breaker class

### DIFF
--- a/src/Breaker.php
+++ b/src/Breaker.php
@@ -59,6 +59,13 @@ class Breaker
      * @var EventDispatcherInterface
      */
     protected $dispatcher;
+    
+    /**
+     * $circuit
+     *
+     * @var Circuit
+     */
+    protected $circuit;
 
     /**
      * Constructor.


### PR DESCRIPTION
Salut Guillaume! Tiny missing declaration, nothing fancy.