### PR TITLE
Added "allowed_exceptions" option

### DIFF
--- a/src/Breaker.php
+++ b/src/Breaker.php
@@ -59,7 +59,7 @@ class Breaker
      * @var EventDispatcherInterface
      */
     protected $dispatcher;
-    
+
     /**
      * $circuit
      *
@@ -89,11 +89,13 @@ class Breaker
             'reset_timeout' => 5,
             'exclude_exceptions' => [],
             'ignore_exceptions' => false,
+            'allowed_exceptions' => [],
         ]);
 
         $resolver->setAllowedTypes('exclude_exceptions', 'array');
         $resolver->setAllowedTypes('max_failure', 'int');
         $resolver->setAllowedTypes('reset_timeout', 'int');
+        $resolver->setAllowedTypes('allowed_exceptions', 'array');
 
         $this->config = $resolver->resolve($config);
         $this->store = $store ?: new ArrayCache();
@@ -124,7 +126,9 @@ class Breaker
                 $circuitOpenException = new CircuitOpenException();
             }
         } catch (\Exception $e) {
-            $this->failure($this->circuit);
+            if (!in_array(get_class($e), $this->config['allowed_exceptions'])) {
+                $this->failure($this->circuit);
+            }
 
             if (!$this->config['ignore_exceptions']) {
                 if (!in_array(get_class($e), $this->config['exclude_exceptions'])) {

--- a/src/Breaker.php
+++ b/src/Breaker.php
@@ -188,13 +188,14 @@ class Breaker
      */
     protected function isOpen(Circuit $circuit)
     {
+        $open = false;
         if ($this->handler->isOpen($circuit)) {
             $this->dispatcher->dispatch(CircuitEvents::OPEN, (new CircuitEvent($circuit)));
 
-            return true;
+            $open = true;
         }
 
-        return false;
+        return $open;
     }
 
     /**


### PR DESCRIPTION
An exception not always implies a failure of the circuit. Sometimes an exception might be thrown because of some sort of validation issue and we might not want to count it as a failure.

To address that, I added the `allowed_exceptions` option. It is just an array of exceptions that, when detected, will skip the `failure()` method but other behavior (like `ignore_exceptions` and `exclude_exceptions`) remains unchanged.